### PR TITLE
export items support

### DIFF
--- a/src/app/core/models/general-setting.model.ts
+++ b/src/app/core/models/general-setting.model.ts
@@ -7,6 +7,7 @@ export type GeneralSetting = {
     import_tax_items: boolean;
     change_accounting_period: boolean;
     import_categories: boolean;
+    import_items: boolean;
     sync_fyle_to_netsuite_payments: boolean;
     sync_netsuite_to_fyle_payments: boolean;
     auto_create_destination_entity: boolean;

--- a/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.html
+++ b/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.html
@@ -131,6 +131,19 @@
         </div>
       </mat-slide-toggle>
 
+      <mat-slide-toggle color="primary" class="schedule" *ngIf="showImportItems" formControlName="importItems">
+        <div class="schedule--toggle-text">
+          Import NetSuite Items into Fyle
+          <mat-icon
+            [inline]="true"
+            class="info-icon"
+            [matTooltip]="'Import NetSuite Items as categories in Fyle'"
+            matTooltipPosition="after">
+              info
+          </mat-icon>
+        </div>
+      </mat-slide-toggle>
+
       <mat-slide-toggle color="primary" class="schedule" *ngIf="showPaymentsandProjectsField" formControlName="importProjects">
         <div class="schedule--toggle-text">
           Import NetSuite Projects / Customers into Fyle

--- a/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.ts
+++ b/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.ts
@@ -105,8 +105,6 @@ export class ConfigurationComponent implements OnInit {
     if ((that.generalSettings.reimbursable_expenses_object === 'BILL' && (!that.generalSettings.corporate_credit_card_expenses_object))
         || (that.generalSettings.reimbursable_expenses_object === 'BILL' && that.generalSettings.corporate_credit_card_expenses_object === 'BILL')) {
       that.showImportItems = true;
-    } else {
-      that.showImportItems = false;
     }
     that.showImportEmployeeOption(that.generalSettings.employee_field_mapping);
 
@@ -173,6 +171,7 @@ export class ConfigurationComponent implements OnInit {
         if (reimbursableExpenseMappedTo === 'BILL') {
           that.showImportItems = true;
         } else {
+          that.showImportItems = false;
           that.generalSettingsForm.controls.importItems.setValue(false);
         }
       }

--- a/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.ts
+++ b/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.ts
@@ -33,6 +33,7 @@ export class ConfigurationComponent implements OnInit {
   showAutoCreateMerchant: boolean;
   netsuiteSubsidiaryCountry: string;
   showImportCategories: boolean;
+  showImportItems: boolean;
   showImportEmployees: boolean;
   cardsMapping = false;
 
@@ -101,6 +102,12 @@ export class ConfigurationComponent implements OnInit {
     that.cccExpenseOptions = that.getCCCExpenseOptions(that.generalSettings.reimbursable_expenses_object);
     that.showPaymentsandProjectFields(that.generalSettings.reimbursable_expenses_object);
     that.showImportCategories = true;
+    if ((that.generalSettings.reimbursable_expenses_object === 'BILL' && (that.generalSettings.corporate_credit_card_expenses_object === null || that.generalSettings.corporate_credit_card_expenses_object === 'undefined'))
+        || (that.generalSettings.reimbursable_expenses_object === 'BILL' && that.generalSettings.corporate_credit_card_expenses_object === 'BILL')) {
+      that.showImportItems = true;
+    } else {
+      that.showImportItems = false;
+    }
     that.showImportEmployeeOption(that.generalSettings.employee_field_mapping);
 
     if (that.generalSettings.corporate_credit_card_expenses_object && that.generalSettings.corporate_credit_card_expenses_object === 'CREDIT CARD CHARGE') {
@@ -162,10 +169,31 @@ export class ConfigurationComponent implements OnInit {
           // turn off the import categories toggle when the user switches from EXPENSE REPORT to something else
           that.generalSettingsForm.controls.importCategories.setValue(false);
         }
+
+        if (reimbursableExpenseMappedTo === 'BILL') {
+          that.showImportItems = true;
+        } else {
+          that.showImportItems = false;
+          that.generalSettingsForm.controls.importItems.setValue(false);
+        }
       }
 
       if (that.generalSettings && that.generalSettings.sync_fyle_to_netsuite_payments && !that.showPaymentsandProjectsField) {
         that.generalSettingsForm.controls.paymentsSync.setValue(false);
+      }
+    });
+  }
+
+  setupCccExpenseFieldWatcher() {
+    const that = this;
+
+    that.generalSettingsForm.controls.cccExpense.valueChanges.subscribe((cccExpenseMappedTo) => {
+      const reimbursableExpenseMappedTo = that.generalSettingsForm.controls.reimbursableExpense.value;
+      if ((cccExpenseMappedTo === 'BILL' || cccExpenseMappedTo === null || cccExpenseMappedTo === undefined) && reimbursableExpenseMappedTo === 'BILL') {
+        that.showImportItems = true;
+      } else {
+        that.showImportItems = false;
+        that.generalSettingsForm.controls.importItems.setValue(false);
       }
     });
   }
@@ -187,6 +215,9 @@ export class ConfigurationComponent implements OnInit {
 
     // Reimbursable Expense Mapping
     that.setupReimbursableFieldWatcher();
+
+    // CCC Expense Mapping
+    that.setupCccExpenseFieldWatcher();
 
     // Auto Create Merchant
     that.generalSettingsForm.controls.cccExpense.valueChanges.subscribe((cccExpenseMappedTo) => {
@@ -240,6 +271,7 @@ export class ConfigurationComponent implements OnInit {
         importProjects: [importProjects],
         changeAccountingPeriod: [that.generalSettings.change_accounting_period],
         importCategories: [that.generalSettings.import_categories],
+        importItems: [that.generalSettings.import_items],
         importTaxDetails: [that.generalSettings.import_tax_items],
         paymentsSync: [paymentsSyncOption],
         autoMapEmployees: [that.generalSettings.auto_map_employees],
@@ -259,6 +291,7 @@ export class ConfigurationComponent implements OnInit {
         cccExpense: [null],
         importProjects: [false],
         importCategories: [false],
+        importItems: [false],
         importTaxDetails: [false],
         changeAccountingPeriod: [false],
         paymentsSync: [null],
@@ -399,6 +432,7 @@ export class ConfigurationComponent implements OnInit {
       import_projects: false,
       change_accounting_period: that.generalSettingsForm.value.changeAccountingPeriod ? that.generalSettingsForm.value.changeAccountingPeriod : false,
       import_categories: that.generalSettingsForm.value.importCategories,
+      import_items: that.generalSettingsForm.value.importItems,
       import_tax_items: that.generalSettingsForm.value.importTaxDetails ? that.generalSettingsForm.value.importTaxDetails : false,
       auto_map_employees: that.generalSettingsForm.value.autoMapEmployees ? that.generalSettingsForm.value.autoMapEmployees : null,
       auto_create_destination_entity: that.generalSettingsForm.value.autoCreateDestinationEntity,

--- a/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.ts
+++ b/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.ts
@@ -102,7 +102,7 @@ export class ConfigurationComponent implements OnInit {
     that.cccExpenseOptions = that.getCCCExpenseOptions(that.generalSettings.reimbursable_expenses_object);
     that.showPaymentsandProjectFields(that.generalSettings.reimbursable_expenses_object);
     that.showImportCategories = true;
-    if ((that.generalSettings.reimbursable_expenses_object === 'BILL' && (that.generalSettings.corporate_credit_card_expenses_object === null || that.generalSettings.corporate_credit_card_expenses_object === 'undefined'))
+    if ((that.generalSettings.reimbursable_expenses_object === 'BILL' && (!that.generalSettings.corporate_credit_card_expenses_object))
         || (that.generalSettings.reimbursable_expenses_object === 'BILL' && that.generalSettings.corporate_credit_card_expenses_object === 'BILL')) {
       that.showImportItems = true;
     } else {
@@ -173,7 +173,6 @@ export class ConfigurationComponent implements OnInit {
         if (reimbursableExpenseMappedTo === 'BILL') {
           that.showImportItems = true;
         } else {
-          that.showImportItems = false;
           that.generalSettingsForm.controls.importItems.setValue(false);
         }
       }
@@ -189,7 +188,7 @@ export class ConfigurationComponent implements OnInit {
 
     that.generalSettingsForm.controls.cccExpense.valueChanges.subscribe((cccExpenseMappedTo) => {
       const reimbursableExpenseMappedTo = that.generalSettingsForm.controls.reimbursableExpense.value;
-      if ((cccExpenseMappedTo === 'BILL' || cccExpenseMappedTo === null || cccExpenseMappedTo === undefined) && reimbursableExpenseMappedTo === 'BILL') {
+      if ((cccExpenseMappedTo === 'BILL' || !cccExpenseMappedTo) && reimbursableExpenseMappedTo === 'BILL') {
         that.showImportItems = true;
       } else {
         that.showImportItems = false;

--- a/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.ts
+++ b/src/app/netsuite/settings/netsuite-configurations/configuration/configuration.component.ts
@@ -102,8 +102,7 @@ export class ConfigurationComponent implements OnInit {
     that.cccExpenseOptions = that.getCCCExpenseOptions(that.generalSettings.reimbursable_expenses_object);
     that.showPaymentsandProjectFields(that.generalSettings.reimbursable_expenses_object);
     that.showImportCategories = true;
-    if ((that.generalSettings.reimbursable_expenses_object === 'BILL' && (!that.generalSettings.corporate_credit_card_expenses_object))
-        || (that.generalSettings.reimbursable_expenses_object === 'BILL' && that.generalSettings.corporate_credit_card_expenses_object === 'BILL')) {
+    if (that.generalSettings.reimbursable_expenses_object === 'BILL' && (!that.generalSettings.corporate_credit_card_expenses_object || that.generalSettings.corporate_credit_card_expenses_object === 'BILL')) {
       that.showImportItems = true;
     }
     that.showImportEmployeeOption(that.generalSettings.employee_field_mapping);


### PR DESCRIPTION
- The import_items flag should only be enabled if the export type is BILL . 
- If even one of the export Type is set as anything other than BILL the import_item option should be disabled and not shown in the configurations page.